### PR TITLE
Update thank-you page badge icon and accent styling

### DIFF
--- a/thank-you.html
+++ b/thank-you.html
@@ -14,7 +14,7 @@
   <meta property="og:url" content="https://mypooch.ie/thank-you.html" />
   <meta property="og:image" content="./og-image.png" />
 
-  <link rel="icon" type="image/svg+xml" href="mypooch_fav.svg" />
+  <link rel="icon" type="image/svg+xml" href="mypooch_logo.svg" />
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@600&display=swap" rel="stylesheet">
 
   <style>
@@ -58,10 +58,10 @@
       border: 1px solid var(--border);
     }
 
-    .badge svg {
-      width: 84px;
-      height: 84px;
-      stroke: var(--accent-dark);
+    .badge img {
+      width: 92px;
+      height: 92px;
+      display: block;
     }
 
     h1 {
@@ -110,6 +110,10 @@
       color: var(--fg);
     }
 
+    strong {
+      color: var(--accent-dark);
+    }
+
     a.button {
       display: inline-flex;
       align-items: center;
@@ -148,10 +152,7 @@
 <body>
   <main role="main">
     <div class="badge" aria-hidden="true">
-      <svg viewBox="0 0 24 24" fill="none" stroke-width="1.8" xmlns="http://www.w3.org/2000/svg">
-        <circle cx="12" cy="12" r="9" stroke="currentColor" fill="rgba(151,209,169,0.18)" />
-        <path d="m9.2 12.5 2 2.1 4-4.3" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" />
-      </svg>
+      <img src="./mypooch_logo.svg" alt="My Pooch logo" />
     </div>
 
     <h1>Thank you for joining the pack!</h1>


### PR DESCRIPTION
## Summary
- replace the thank-you badge graphic with the My Pooch logo asset for consistency across pages
- update the favicon reference to use `mypooch_logo.svg` and apply the accent color to bold text

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68ca4f65a26083219c598f4ed83869ee