### PR TITLE
Adjust text tone and link palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,11 @@
   <style>
     :root {
       --bg: #fafafa;
-      --fg: #121212;
+      --fg: #333333;
       --muted: #6b7280;
       --accent-dark: #51717e; /* zielonoszary */
       --accent-light: #97d1a9; /* jasnozielony */
+      --link: #fab0a0; /* pastelowy pomarańcz */
       --ring: rgba(151,209,169,0.25);
     }
 
@@ -99,7 +100,7 @@ button:active {
 
 
     .legal { margin-top: 1rem; font-size: .9rem; color: var(--muted); }
-    .legal a { color: var(--accent-dark); text-decoration: none; }
+    .legal a { color: var(--link); text-decoration: none; }
     .legal a:hover { text-decoration: underline; }
     .footer { margin-top: 3rem; font-size: .85rem; color: var(--muted); }
 

--- a/privacy.html
+++ b/privacy.html
@@ -21,10 +21,11 @@
   <style>
     :root {
       --bg:#fafafa;
-      --fg:#121212;
+      --fg:#333333;
       --muted:#6b7280;
       --accent-dark:#51717e;  /* zielonoszary */
       --accent-light:#97d1a9; /* jasnozielony */
+      --link:#fab0a0; /* pastelowy pomarańcz */
       --ring:rgba(151,209,169,0.25);
       --card:#ffffff;
       --border:#e5e7eb;
@@ -37,6 +38,8 @@
       color:var(--fg); background:var(--bg);
     }
     .wrap{max-width:880px;margin:0 auto;padding:4rem 1.25rem}
+    a{color:var(--link);}
+    a:hover{text-decoration:underline}
     .back{color:var(--muted);text-decoration:none}
     .back:hover{text-decoration:underline}
     .head{display:flex;align-items:center;gap:1rem;margin:0 0 1rem}
@@ -54,14 +57,14 @@
     }
     .muted{color:var(--muted);margin:.25rem 0 0}
     nav{margin:1.25rem 0 2rem;display:flex;flex-wrap:wrap;gap:.75rem}
-    nav a{color:var(--accent-dark);text-decoration:none;font-size:.95rem}
+    nav a{color:var(--link);text-decoration:none;font-size:.95rem}
     nav a:hover{text-decoration:underline}
     .card{
       background:var(--card);border:1px solid var(--border);border-radius:16px;
       padding:1.1rem 1.25rem;margin:1rem 0;
     }
     h2{margin:0 0 .5rem;font-size:1.15rem;color:var(--accent-dark)}
-    p,li{color:#222}
+    p,li{color:var(--fg)}
     strong{color:var(--accent-dark)}
     code{
       background:#f1f5f9;border:1px solid #e2e8f0;border-radius:6px;

--- a/thank-you.html
+++ b/thank-you.html
@@ -14,16 +14,17 @@
   <meta property="og:url" content="https://mypooch.ie/thank-you.html" />
   <meta property="og:image" content="./og-image.png" />
 
-  <link rel="icon" type="image/svg+xml" href="mypooch_fav.svg" />
+  <link rel="icon" type="image/svg+xml" href="mypooch_logo.svg" />
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@600&display=swap" rel="stylesheet">
 
   <style>
     :root {
       --bg: #fafafa;
-      --fg: #121212;
+      --fg: #333333;
       --muted: #6b7280;
       --accent-dark: #51717e;
       --accent-light: #97d1a9;
+      --link: #fab0a0;
       --ring: rgba(151, 209, 169, 0.25);
       --card: #ffffff;
       --border: #e5e7eb;
@@ -38,6 +39,14 @@
       color: var(--fg);
       display: grid;
       place-items: center;
+    }
+
+    a:not(.button) {
+      color: var(--link);
+    }
+
+    a:not(.button):hover {
+      text-decoration: underline;
     }
 
     main {
@@ -58,10 +67,10 @@
       border: 1px solid var(--border);
     }
 
-    .badge svg {
-      width: 84px;
-      height: 84px;
-      stroke: var(--accent-dark);
+    .badge img {
+      width: 92px;
+      height: 92px;
+      display: block;
     }
 
     h1 {
@@ -110,6 +119,10 @@
       color: var(--fg);
     }
 
+    strong {
+      color: var(--accent-dark);
+    }
+
     a.button {
       display: inline-flex;
       align-items: center;
@@ -133,7 +146,7 @@
     }
 
     .footer a {
-      color: var(--accent-dark);
+      color: var(--link);
       text-decoration: none;
     }
 
@@ -148,10 +161,7 @@
 <body>
   <main role="main">
     <div class="badge" aria-hidden="true">
-      <svg viewBox="0 0 24 24" fill="none" stroke-width="1.8" xmlns="http://www.w3.org/2000/svg">
-        <circle cx="12" cy="12" r="9" stroke="currentColor" fill="rgba(151,209,169,0.18)" />
-        <path d="m9.2 12.5 2 2.1 4-4.3" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" />
-      </svg>
+      <img src="./mypooch_logo.svg" alt="My Pooch logo" />
     </div>
 
     <h1>Thank you for joining the pack!</h1>


### PR DESCRIPTION
## Summary
- switch the default foreground colour on the landing, privacy and thank-you pages to an 80% black grey for softer contrast
- restyle inline links on all three pages to use the warm orange accent pulled from the logo while keeping existing button styling intact

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68ca4f65a26083219c598f4ed83869ee