### PR TITLE
Adjust link color to darker green

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       --muted: #6b7280;
       --accent-dark: #51717e; /* zielonoszary */
       --accent-light: #97d1a9; /* jasnozielony */
-      --link: #97d1a9; /* jasnozielony */
+      --link: #5fa87a; /* ciemniejszy odcień zieleni zgodny z logo */
       --ring: rgba(151,209,169,0.25);
     }
 
@@ -100,7 +100,7 @@ button:active {
 
 
     .legal { margin-top: 1rem; font-size: .9rem; color: var(--muted); }
-    .legal a { color: var(--link); text-decoration: none; font-weight: 700; }
+    .legal a { color: var(--link); text-decoration: none; }
     .legal a:hover { text-decoration: underline; }
     .footer { margin-top: 3rem; font-size: .85rem; color: var(--muted); }
 

--- a/privacy.html
+++ b/privacy.html
@@ -25,7 +25,7 @@
       --muted:#51717e;
       --accent-dark:#51717e;  /* zielonoszary */
       --accent-light:#97d1a9; /* jasnozielony */
-      --link:#97d1a9; /* jasnozielony */
+      --link:#5fa87a; /* ciemniejszy odcień zieleni zgodny z logo */
       --ring:rgba(151,209,169,0.25);
       --card:#ffffff;
       --border:#e5e7eb;
@@ -38,7 +38,7 @@
       color:var(--fg); background:var(--bg);
     }
     .wrap{max-width:880px;margin:0 auto;padding:4rem 1.25rem}
-    a{color:var(--link);font-weight:700;}
+    a{color:var(--link);}
     a:hover{text-decoration:underline}
     .back{color:var(--link);text-decoration:none}
     .back:hover{text-decoration:underline}

--- a/thank-you.html
+++ b/thank-you.html
@@ -24,7 +24,7 @@
       --muted: #51717e;
       --accent-dark: #51717e;
       --accent-light: #97d1a9;
-      --link: #97d1a9;
+      --link: #5fa87a; /* ciemniejszy odcień zieleni zgodny z logo */
       --ring: rgba(151, 209, 169, 0.25);
       --card: #ffffff;
       --border: #e5e7eb;
@@ -43,7 +43,6 @@
 
     a:not(.button) {
       color: var(--link);
-      font-weight: 700;
     }
 
     a:not(.button):hover {


### PR DESCRIPTION
## Summary
- update the link color variable across the static pages to a darker green that aligns with the logo palette
- remove bold styling from standard links now that the darker tone provides emphasis

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68caa7429c4883219ef881057f393cb8