### PR TITLE
Improve SEO metadata and add 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Content-Language" content="en" />
+  <title>Page not found — My Pooch</title>
+  <meta name="description" content="Sorry, we can't find the page you're looking for on My Pooch." />
+  <meta name="robots" content="noindex, nofollow" />
+  <link rel="canonical" href="https://mypooch.ie/404" />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Page not found — My Pooch" />
+  <meta property="og:description" content="The page you requested doesn't exist. Head back to mypooch.ie." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://mypooch.ie/404" />
+  <meta property="og:image" content="https://mypooch.ie/mypooch_97D1A9.svg" />
+
+  <link rel="icon" type="image/svg+xml" href="mypooch_fav.svg" />
+  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@600&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --bg: #fafafa;
+      --fg: #333333;
+      --muted: #6b7280;
+      --accent-dark: #51717e;
+      --accent-light: #97d1a9;
+      --link: #5fa87a;
+      --card: #ffffff;
+      --border: #e5e7eb;
+    }
+
+    * { box-sizing: border-box; }
+    html, body { height: 100%; }
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      background: var(--bg);
+      color: var(--fg);
+      display: grid;
+      place-items: center;
+    }
+
+    main {
+      width: min(660px, 92vw);
+      padding: 5rem 1.5rem 4rem;
+      text-align: center;
+    }
+
+    .logo-card {
+      width: 120px;
+      height: 120px;
+      margin: 0 auto 1.5rem;
+      border-radius: 32px;
+      background: var(--card);
+      display: grid;
+      place-items: center;
+      box-shadow: 0 6px 24px rgba(0,0,0,.06);
+      border: 1px solid var(--border);
+    }
+
+    .logo-card img {
+      width: 96px;
+      height: 96px;
+      display: block;
+    }
+
+    h1 {
+      font-family: 'Baloo 2', sans-serif;
+      font-size: clamp(32px, 4vw, 48px);
+      line-height: 1.08;
+      margin: 0 0 .75rem;
+      letter-spacing: -0.01em;
+      color: var(--accent-dark);
+    }
+
+    p {
+      margin: 0 0 1.75rem;
+      color: var(--muted);
+      font-size: 1.05rem;
+    }
+
+    .actions {
+      display: flex;
+      justify-content: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .actions a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: .85rem 1.4rem;
+      border-radius: 14px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: transform .04s ease, filter .15s ease;
+    }
+
+    .actions a.primary {
+      background: var(--accent-dark);
+      color: #fff;
+    }
+
+    .actions a.secondary {
+      background: var(--card);
+      color: var(--accent-dark);
+      border: 1px solid var(--border);
+    }
+
+    .actions a:hover { filter: brightness(1.05); }
+    .actions a:active { transform: translateY(1px); }
+
+    footer {
+      margin-top: 2.5rem;
+      font-size: .9rem;
+      color: var(--muted);
+    }
+
+    footer a {
+      color: var(--link);
+      text-decoration: none;
+    }
+
+    footer a:hover { text-decoration: underline; }
+
+    @media (max-width: 520px) {
+      main { padding-top: 4.25rem; }
+    }
+  </style>
+</head>
+<body>
+  <main role="main">
+    <div class="logo-card" aria-hidden="true">
+      <img src="./mypooch_logo.svg" alt="My Pooch logo" />
+    </div>
+    <h1>We couldn't find that page</h1>
+    <p>The link might be broken or the page may have moved. Let's get you back on track.</p>
+    <div class="actions">
+      <a class="primary" href="/">Go to homepage</a>
+      <a class="secondary" href="privacy.html">Privacy policy</a>
+    </div>
+    <footer>Need help? Email <a href="mailto:info@mypooch.ie">info@mypooch.ie</a>.</footer>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -14,17 +14,38 @@
   
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Content-Language" content="en" />
   <title>My Pooch — coming soon</title>
   <meta name="description" content="My Pooch — beautiful, practical things for you and your dog. Join the list to be first to know." />
   <meta name="robots" content="index, follow" />
   <meta name="keywords" content="dogs, cats, pet accessories, lifestyle, my pooch" />
+  <link rel="canonical" href="https://mypooch.ie/" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="My Pooch — coming soon" />
   <meta property="og:description" content="Join the waitlist to be first to know." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://mypooch.ie" />
-  <meta property="og:image" content="./og-image.png" />
+  <meta property="og:image" content="https://mypooch.ie/mypooch_97D1A9.svg" />
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "My Pooch",
+    "url": "https://mypooch.ie/",
+    "logo": "https://mypooch.ie/mypooch_logo.svg",
+    "description": "My Pooch — beautiful, practical things for you and your dog.",
+    "contactPoint": [
+      {
+        "@type": "ContactPoint",
+        "contactType": "customer service",
+        "email": "info@mypooch.ie",
+        "areaServed": "IE"
+      }
+    ]
+  }
+  </script>
 
   <link rel="icon" type="image/svg+xml" href="mypooch_fav.svg" />
 
@@ -117,6 +138,7 @@ button:active {
     .footer { margin-top: 3rem; font-size: .85rem; color: var(--muted); }
 
     .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); border:0; }
+    .hp-field { position:absolute; left:-10000px; top:auto; width:1px; height:1px; overflow:hidden; }
 
     /* simple success message state (hash-based) */
     #success { display: none; margin-top: 1.5rem; color: var(--accent-dark); font-weight: 600; }
@@ -139,9 +161,13 @@ button:active {
     <label for="email" class="sr-only">Email address</label>
     <input id="email" name="email" type="email" placeholder="you@example.com" required autocomplete="email" />
   </div>
+  <div class="hp-field" aria-hidden="true">
+    <label for="company">Company</label>
+    <input id="company" name="company" type="text" tabindex="-1" autocomplete="off" />
+  </div>
   <button type="submit">Notify me</button>
   <input type="hidden" name="subject" value="My Pooch — new waitlist signup" />
-  <input type="hidden" name="_next" value="https://mypooch.ie/#success" />
+  <input type="hidden" name="_next" value="https://mypooch.ie/thank-you" />
 </form>
 
     <p id="success">Thanks! You’re on the list.</p>
@@ -157,7 +183,20 @@ button:active {
   <noscript><div style="text-align:center;color:#6b7280">JavaScript is disabled — the page works, but some enhancements may be limited.</div></noscript>
 
   <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
+    const yearTarget = document.getElementById('year');
+    if (yearTarget) {
+      yearTarget.textContent = new Date().getFullYear();
+    }
+
+    const waitlistForm = document.querySelector('form[aria-label="Join the waitlist"]');
+    if (waitlistForm) {
+      waitlistForm.addEventListener('submit', (event) => {
+        const honeypot = waitlistForm.querySelector('input[name="company"]');
+        if (honeypot && honeypot.value.trim() !== '') {
+          event.preventDefault();
+        }
+      });
+    }
   </script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -14,16 +14,18 @@
   
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Content-Language" content="en" />
   <title>Privacy Policy — My Pooch</title>
   <meta name="description" content="Privacy Policy for My Pooch (mypooch.ie). GDPR-compliant notice about the data we collect, why, and your rights." />
   <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://mypooch.ie/privacy.html" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Privacy Policy — My Pooch" />
   <meta property="og:description" content="How My Pooch handles your data in line with GDPR." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://mypooch.ie/privacy.html" />
-  <meta property="og:image" content="./og-image.png" />
+  <meta property="og:image" content="https://mypooch.ie/mypooch_97D1A9.svg" />
 
   <!-- Favicon + fonts -->
   <link rel="icon" type="image/svg+xml" href="mypooch_logo.svg" />

--- a/thank-you.html
+++ b/thank-you.html
@@ -3,16 +3,18 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Content-Language" content="en" />
   <title>Thank you — My Pooch</title>
   <meta name="description" content="Thank you for joining the My Pooch waitlist. Here's what happens next." />
   <meta name="robots" content="noindex, nofollow" />
+  <link rel="canonical" href="https://mypooch.ie/thank-you" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Thank you — My Pooch" />
   <meta property="og:description" content="You're on the My Pooch waitlist. We'll be in touch with updates soon." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://mypooch.ie/thank-you.html" />
-  <meta property="og:image" content="./og-image.png" />
+  <meta property="og:url" content="https://mypooch.ie/thank-you" />
+  <meta property="og:image" content="https://mypooch.ie/mypooch_97D1A9.svg" />
 
   <link rel="icon" type="image/svg+xml" href="mypooch_logo.svg" />
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@600&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- add canonical URLs, content language hints, and structured data to improve SEO signals
- update Open Graph artwork to use mypooch_97D1A9.svg across public pages and enhance the waitlist form with a honeypot + redirect to /thank-you
- create a branded 404 page for friendlier error handling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc9e0059b0832188346a3b5af2b743