### PR TITLE
Add cookie consent banner and update privacy statements

### DIFF
--- a/404.html
+++ b/404.html
@@ -126,10 +126,23 @@
 
     footer a:hover { text-decoration: underline; }
 
+    .cookie-manage {
+      background: none;
+      border: none;
+      padding: 0;
+      font: inherit;
+      color: var(--link);
+      cursor: pointer;
+    }
+
+    .cookie-manage:hover, .cookie-manage:focus { text-decoration: underline; }
+    .cookie-manage:focus-visible { outline: 2px solid var(--accent-light); outline-offset: 2px; border-radius: 4px; }
+
     @media (max-width: 520px) {
       main { padding-top: 4.25rem; }
     }
   </style>
+  <script src="cookie-consent.js" defer></script>
 </head>
 <body>
   <main role="main">
@@ -142,7 +155,7 @@
       <a class="primary" href="/">Go to homepage</a>
       <a class="secondary" href="privacy.html">Privacy policy</a>
     </div>
-    <footer>Need help? Email <a href="mailto:info@mypooch.ie">info@mypooch.ie</a>.</footer>
+    <footer>Need help? Email <a href="mailto:info@mypooch.ie">info@mypooch.ie</a>. · <button type="button" class="cookie-manage" data-cookie-consent="manage">Cookie settings</button></footer>
   </main>
 </body>
 </html>

--- a/cookie-consent.js
+++ b/cookie-consent.js
@@ -1,0 +1,296 @@
+(function () {
+  const win = window;
+  const doc = document;
+  const GA_ID = 'G-BB67XV4TK2';
+  const STORAGE_KEY = 'mypooch.cookieConsent';
+  const CONSENT_ACCEPTED = 'accepted';
+  const CONSENT_DECLINED = 'declined';
+  const GA_DISABLE_KEY = `ga-disable-${GA_ID}`;
+  const CONSENT_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 12 months
+
+  win[GA_DISABLE_KEY] = true;
+
+  let bannerEl = null;
+  let stylesInjected = false;
+  let analyticsLoaded = false;
+  let localStorageUsable = true;
+
+  try {
+    const testKey = `${STORAGE_KEY}.test`;
+    win.localStorage.setItem(testKey, '1');
+    win.localStorage.removeItem(testKey);
+  } catch (error) {
+    localStorageUsable = false;
+  }
+
+  function getStoredPreference() {
+    if (localStorageUsable) {
+      try {
+        return win.localStorage.getItem(STORAGE_KEY);
+      } catch (error) {
+        // fall back to cookies
+      }
+    }
+
+    try {
+      const match = doc.cookie.match(new RegExp(`(?:^|; )${STORAGE_KEY}=([^;]*)`));
+      return match ? decodeURIComponent(match[1]) : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function storePreference(value) {
+    if (localStorageUsable) {
+      try {
+        win.localStorage.setItem(STORAGE_KEY, value);
+        return;
+      } catch (error) {
+        // fall back to cookies
+      }
+    }
+
+    try {
+      const secure = win.location.protocol === 'https:' ? ';Secure' : '';
+      doc.cookie = `${STORAGE_KEY}=${encodeURIComponent(value)};path=/;max-age=${CONSENT_COOKIE_MAX_AGE};SameSite=Lax${secure}`;
+    } catch (error) {
+      // swallow write errors
+    }
+  }
+
+  function injectStyles() {
+    if (stylesInjected) {
+      return;
+    }
+
+    const style = doc.createElement('style');
+    style.id = 'cookie-consent-styles';
+    style.textContent = `
+      .cookie-consent { position: fixed; left: 1rem; right: 1rem; bottom: 1rem; margin: 0 auto; max-width: 560px; background: #ffffff; color: #1f2937; border-radius: 20px; box-shadow: 0 18px 48px rgba(15,23,42,.18); border: 1px solid rgba(81,113,126,.15); padding: 1.5rem; z-index: 2147483640; display: none; }
+      .cookie-consent--visible { display: block; animation: cookie-consent-slide .28s ease-out; }
+      .cookie-consent__inner { display: grid; gap: 0.75rem; }
+      .cookie-consent__heading { margin: 0; font-weight: 700; font-size: 1.05rem; color: #111827; }
+      .cookie-consent__text { margin: 0; color: #374151; font-size: .95rem; line-height: 1.5; }
+      .cookie-consent__status { margin: 0; color: #4b5563; font-size: .85rem; }
+      .cookie-consent__actions { display: flex; flex-wrap: wrap; gap: .75rem; align-items: center; }
+      .cookie-consent__button { cursor: pointer; font-weight: 600; font-size: .95rem; border-radius: 12px; border: none; padding: .75rem 1.25rem; }
+      .cookie-consent__button--primary { background: #51717e; color: #ffffff; }
+      .cookie-consent__button--primary:hover { filter: brightness(1.05); }
+      .cookie-consent__button--secondary { background: transparent; border: 1px solid rgba(81,113,126,.4); color: #51717e; }
+      .cookie-consent__button--secondary:hover { background: rgba(81,113,126,.08); }
+      .cookie-consent__button:focus-visible { outline: 2px solid #97d1a9; outline-offset: 2px; }
+      .cookie-consent__link { color: #5fa87a; text-decoration: none; font-weight: 600; }
+      .cookie-consent__link:hover, .cookie-consent__link:focus { text-decoration: underline; }
+      .cookie-consent__link:focus-visible { outline: 2px solid #97d1a9; outline-offset: 2px; border-radius: 4px; }
+      .cookie-consent__actions > * { flex-shrink: 0; }
+      @keyframes cookie-consent-slide { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+      @media (max-width: 600px) { .cookie-consent { padding: 1.25rem; bottom: .75rem; } .cookie-consent__actions { flex-direction: column; align-items: stretch; } .cookie-consent__button { width: 100%; text-align: center; } }
+      @media (prefers-reduced-motion: reduce) { .cookie-consent--visible { animation: none; } }
+    `;
+    doc.head.appendChild(style);
+    stylesInjected = true;
+  }
+
+  function ensureGtag() {
+    win.dataLayer = win.dataLayer || [];
+    if (typeof win.gtag !== 'function') {
+      win.gtag = function gtag() {
+        win.dataLayer.push(arguments);
+      };
+    }
+  }
+
+  function enableAnalytics() {
+    win[GA_DISABLE_KEY] = false;
+    ensureGtag();
+
+    if (!analyticsLoaded) {
+      win.gtag('consent', 'default', {
+        analytics_storage: 'denied',
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+        functionality_storage: 'granted',
+        security_storage: 'granted'
+      });
+    }
+
+    win.gtag('consent', 'update', {
+      analytics_storage: 'granted',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied'
+    });
+
+    if (!analyticsLoaded) {
+      analyticsLoaded = true;
+      const script = doc.createElement('script');
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
+      script.async = true;
+      script.dataset.cookieConsent = 'ga4';
+      doc.head.appendChild(script);
+    }
+
+    win.gtag('js', new Date());
+    win.gtag('config', GA_ID, {
+      anonymize_ip: true,
+      allow_google_signals: false,
+      allow_ad_personalization_signals: false
+    });
+  }
+
+  function disableAnalytics() {
+    win[GA_DISABLE_KEY] = true;
+    if (typeof win.gtag === 'function') {
+      win.gtag('consent', 'update', {
+        analytics_storage: 'denied',
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied'
+      });
+    }
+  }
+
+  function updateStatusText() {
+    if (!bannerEl) {
+      return;
+    }
+
+    const statusEl = bannerEl.querySelector('[data-status]');
+    if (!statusEl) {
+      return;
+    }
+
+    const pref = getStoredPreference();
+    if (pref === CONSENT_ACCEPTED) {
+      statusEl.textContent = 'Current choice: analytics cookies accepted. Use “Decline” to turn them off.';
+    } else if (pref === CONSENT_DECLINED) {
+      statusEl.textContent = 'Current choice: analytics cookies declined. You can enable them anytime.';
+    } else {
+      statusEl.textContent = 'You can change your choice at any time via “Cookie settings”.';
+    }
+  }
+
+  function createBanner() {
+    if (bannerEl) {
+      return bannerEl;
+    }
+
+    bannerEl = doc.createElement('div');
+    bannerEl.className = 'cookie-consent';
+    bannerEl.setAttribute('role', 'dialog');
+    bannerEl.setAttribute('aria-modal', 'false');
+    bannerEl.setAttribute('aria-live', 'polite');
+    bannerEl.setAttribute('aria-labelledby', 'cookie-consent-title');
+    bannerEl.setAttribute('aria-describedby', 'cookie-consent-description cookie-consent-status');
+    bannerEl.innerHTML = `
+      <div class="cookie-consent__inner">
+        <p class="cookie-consent__heading" id="cookie-consent-title">Cookies & analytics</p>
+        <p class="cookie-consent__text" id="cookie-consent-description">We use essential cookies to make our site work. With your permission we’d also like to use Google Analytics 4 to understand traffic and improve mypooch.ie.</p>
+        <p class="cookie-consent__status" id="cookie-consent-status" data-status></p>
+        <div class="cookie-consent__actions">
+          <button type="button" class="cookie-consent__button cookie-consent__button--primary" data-action="accept">Accept analytics</button>
+          <button type="button" class="cookie-consent__button cookie-consent__button--secondary" data-action="decline">Decline</button>
+          <a class="cookie-consent__link" href="/privacy.html">Learn more</a>
+        </div>
+      </div>
+    `;
+
+    doc.body.appendChild(bannerEl);
+
+    const acceptBtn = bannerEl.querySelector('[data-action="accept"]');
+    const declineBtn = bannerEl.querySelector('[data-action="decline"]');
+
+    if (acceptBtn) {
+      acceptBtn.addEventListener('click', handleAccept);
+    }
+
+    if (declineBtn) {
+      declineBtn.addEventListener('click', handleDecline);
+    }
+
+    updateStatusText();
+
+    return bannerEl;
+  }
+
+  function showBanner(focusAccept = false) {
+    const element = createBanner();
+    updateStatusText();
+    element.classList.add('cookie-consent--visible');
+
+    if (focusAccept) {
+      const acceptBtn = element.querySelector('[data-action="accept"]');
+      if (acceptBtn) {
+        acceptBtn.focus();
+      }
+    }
+  }
+
+  function hideBanner() {
+    if (!bannerEl) {
+      return;
+    }
+
+    bannerEl.classList.remove('cookie-consent--visible');
+  }
+
+  function handleAccept() {
+    storePreference(CONSENT_ACCEPTED);
+    enableAnalytics();
+    hideBanner();
+  }
+
+  function handleDecline() {
+    storePreference(CONSENT_DECLINED);
+    disableAnalytics();
+    hideBanner();
+  }
+
+  function handleManageTrigger(event) {
+    const trigger = event.target.closest('[data-cookie-consent="manage"]');
+    if (!trigger) {
+      return;
+    }
+
+    event.preventDefault();
+    showBanner(true);
+  }
+
+  function init() {
+    injectStyles();
+    doc.addEventListener('click', handleManageTrigger);
+
+    const pref = getStoredPreference();
+
+    if (pref === CONSENT_ACCEPTED) {
+      enableAnalytics();
+    } else if (pref === CONSENT_DECLINED) {
+      disableAnalytics();
+    } else {
+      disableAnalytics();
+      showBanner(true);
+    }
+  }
+
+  if (doc.readyState === 'loading') {
+    doc.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  win.MyPoochConsent = {
+    open: function open() {
+      showBanner(true);
+    },
+    accept: function accept() {
+      handleAccept();
+    },
+    decline: function decline() {
+      handleDecline();
+    },
+    status: function status() {
+      return getStoredPreference();
+    }
+  };
+})();

--- a/index.html
+++ b/index.html
@@ -2,16 +2,6 @@
 <html lang="en">
 <head>
 
-  <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-BB67XV4TK2"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-BB67XV4TK2');
-</script>
-  
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="Content-Language" content="en" />
@@ -135,6 +125,16 @@ button:active {
     .legal { margin-top: 1rem; font-size: .9rem; color: var(--muted); }
     .legal a { color: var(--link); text-decoration: none; }
     .legal a:hover { text-decoration: underline; }
+    .cookie-manage {
+      background: none;
+      border: none;
+      padding: 0;
+      font: inherit;
+      color: var(--link);
+      cursor: pointer;
+    }
+    .cookie-manage:hover, .cookie-manage:focus { text-decoration: underline; }
+    .cookie-manage:focus-visible { outline: 2px solid var(--accent-light); outline-offset: 2px; border-radius: 4px; }
     .footer { margin-top: 3rem; font-size: .85rem; color: var(--muted); }
 
     .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); border:0; }
@@ -144,6 +144,7 @@ button:active {
     #success { display: none; margin-top: 1.5rem; color: var(--accent-dark); font-weight: 600; }
     :target#success { display:block; }
   </style>
+  <script src="cookie-consent.js" defer></script>
 </head>
 <body>
   <main class="container" role="main">
@@ -174,13 +175,13 @@ button:active {
 
   <p class="legal">
     By subscribing you agree to receive emails from My Pooch. <br />
-    You can unsubscribe anytime. <a href="privacy.html">Privacy</a>
+    You can unsubscribe anytime. <a href="privacy.html">Privacy</a> · <button type="button" class="cookie-manage" data-cookie-consent="manage">Cookie settings</button>
   </p>
 
-    <p class="footer">© <span id="year"></span> My Pooch. All rights reserved.</p>
+    <p class="footer">© <span id="year"></span> My Pooch. All rights reserved. · <button type="button" class="cookie-manage" data-cookie-consent="manage">Cookie settings</button></p>
   </main>
 
-  <noscript><div style="text-align:center;color:#6b7280">JavaScript is disabled — the page works, but some enhancements may be limited.</div></noscript>
+  <noscript><div style="text-align:center;color:#6b7280">JavaScript is disabled — the page works, but some enhancements (including the cookie banner and analytics) are limited. Analytics cookies are never set without consent.</div></noscript>
 
   <script>
     const yearTarget = document.getElementById('year');

--- a/privacy.html
+++ b/privacy.html
@@ -2,16 +2,6 @@
 <html lang="en">
 <head>
 
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-BB67XV4TK2"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-BB67XV4TK2');
-</script>
-  
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="Content-Language" content="en" />
@@ -83,8 +73,19 @@
       background:#f1f5f9;border:1px solid #e2e8f0;border-radius:6px;
       padding:.1rem .35rem
     }
+    .cookie-manage{
+      background:none;
+      border:none;
+      padding:0;
+      font:inherit;
+      color:var(--link);
+      cursor:pointer;
+    }
+    .cookie-manage:hover,.cookie-manage:focus{text-decoration:underline}
+    .cookie-manage:focus-visible{outline:2px solid var(--accent-light);outline-offset:2px;border-radius:4px}
     footer{margin-top:2.5rem;color:var(--muted);font-size:.9rem}
   </style>
+  <script src="cookie-consent.js" defer></script>
 </head>
 <body>
   <main class="wrap" role="main">
@@ -95,7 +96,7 @@
   </a>
   <div>
     <h1>Privacy Policy</h1>
-    <p class="muted">Last updated: 14 September 2025</p>
+    <p class="muted">Last updated: 18 September 2025</p>
   </div>
 </header>
     
@@ -103,9 +104,9 @@
     <section id="tldr" class="card">
       <h2>TL;DR — In short</h2>
       <ul>
-        <li>We only collect your <strong>email address</strong> when you join our waitlist or contact us.</li>
-        <li>We use it <strong>only to keep in touch</strong> about our launch and products — no spam.</li>
-        <li>Your data is stored securely with trusted providers (Formspree, Titan Mail, GitHub Pages).</li>
+        <li>We collect your <strong>email address and message</strong> when you join our waitlist or contact us.</li>
+        <li>We use optional <strong>Google Analytics 4</strong> to understand traffic trends — it runs only after you accept analytics cookies.</li>
+        <li>Your data is stored securely with trusted providers (Formspree, Titan Mail, GitHub Pages, Google Ireland Ltd. for analytics if enabled).</li>
         <li>You can <strong>unsubscribe anytime</strong> or ask us to delete your data via <a href="mailto:info@mypooch.ie">info@mypooch.ie</a>.</li>
       </ul>
     </section>
@@ -139,6 +140,7 @@
       <ul>
         <li><strong>Contact data</strong> — your email address when you join our waitlist or contact us.</li>
         <li><strong>Message content</strong> — information you include in free-text fields.</li>
+        <li><strong>Analytics data (optional)</strong> — aggregated usage insights such as pages viewed, approximate location (city/country), device type, and events (e.g., form submissions) collected via Google Analytics 4 only after you opt in to analytics cookies. IP addresses are anonymised.</li>
         <li><strong>Technical/operational data</strong> — minimal request logs (IP, user agent, timestamp) for security and reliability.</li>
       </ul>
       <p>Please avoid sharing sensitive (special-category) data. We do not intentionally collect it.</p>
@@ -150,6 +152,7 @@
         <li>To run our waitlist and send you updates (only if you opt in).</li>
         <li>To respond to enquiries and provide support.</li>
         <li>To operate, secure and improve the Site (e.g., troubleshooting, abuse prevention).</li>
+        <li>To understand how people use the Site (analytics) so we can improve content and experience — only after you consent to analytics cookies.</li>
         <li>To comply with legal obligations.</li>
       </ul>
     </section>
@@ -157,7 +160,7 @@
     <section id="legal" class="card">
       <h2>4) Legal bases (GDPR)</h2>
       <ul>
-        <li><strong>Consent</strong> — waitlist/marketing emails.</li>
+        <li><strong>Consent</strong> — waitlist/marketing emails and analytics cookies.</li>
         <li><strong>Legitimate interests</strong> — running a secure website.</li>
         <li><strong>Contract</strong> — responding to messages you send us.</li>
         <li><strong>Legal obligation</strong> — where applicable.</li>
@@ -172,12 +175,13 @@
         <li><strong>Form handling</strong>: Formspree — receives waitlist/contact submissions.</li>
         <li><strong>Email hosting</strong>: Titan Mail — handles <code>@mypooch.ie</code> email.</li>
         <li><strong>Website hosting</strong>: GitHub Pages — serves our static site.</li>
+        <li><strong>Analytics (optional)</strong>: Google Analytics 4 (Google Ireland Ltd.) — provides aggregated usage reports when you consent to analytics cookies.</li>
       </ul>
     </section>
 
     <section id="transfers" class="card">
       <h2>6) International transfers</h2>
-      <p>Some providers may process data outside the EEA. We rely on safeguards such as SCCs or adequacy decisions.</p>
+      <p>Some providers may process data outside the EEA. Formspree and Google Analytics 4 may store data in the United States or other regions. We rely on safeguards such as Standard Contractual Clauses, adequacy decisions, and Google’s EU data residency controls. Analytics data is pseudonymised and collected only when you give consent.</p>
     </section>
 
     <section id="retention" class="card">
@@ -186,6 +190,7 @@
         <li>Waitlist/marketing: until you unsubscribe or we retire the list.</li>
         <li>Enquiries: up to 12 months after last interaction unless needed longer.</li>
         <li>Logs: short, rolling periods unless needed for incidents.</li>
+        <li>Cookie consent choice: stored for up to 12 months (or until you update it) to remember your preferences.</li>
       </ul>
     </section>
 
@@ -195,8 +200,14 @@
     </section>
 
     <section id="cookies" class="card">
-      <h2>9) Cookies</h2>
-      <p>Our site is static. We don’t use tracking cookies. Only minimal local storage may be used (e.g., success message after a form).</p>
+      <h2>9) Cookies & consent</h2>
+      <p>We use a small amount of technology to keep the Site functional and to understand what resonates:</p>
+      <ul>
+        <li><strong>Essential storage</strong> — required to operate the Site, secure our forms, remember that you closed the cookie banner, and store your cookie preference. This uses first-party local storage or a lightweight cookie.</li>
+        <li><strong>Analytics cookies (optional)</strong> — Google Analytics 4 sets first-party cookies only after you consent. They measure visits, pages viewed, approximate location (city/country), device information, and events such as waitlist sign-ups. IP addresses are anonymised and advertising features are disabled.</li>
+      </ul>
+      <p>On your first visit we ask for consent through our banner. Analytics stays disabled until you click “Accept”. If you choose “Decline”, we respect that decision.</p>
+      <p>You can change your mind anytime via the <button type="button" class="cookie-manage" data-cookie-consent="manage">Cookie settings</button> link in the footer. When you withdraw consent we stop sending new analytics data and update Google Consent Mode to disable analytics storage.</p>
     </section>
 
     <section id="security" class="card">
@@ -220,7 +231,7 @@
     </section>
 
     <footer>
-      <p>© <span id="year"></span> My Pooch. All rights reserved.</p>
+      <p>© <span id="year"></span> My Pooch. All rights reserved. · <button type="button" class="cookie-manage" data-cookie-consent="manage">Cookie settings</button></p>
     </footer>
   </main>
 

--- a/thank-you.html
+++ b/thank-you.html
@@ -154,11 +154,24 @@
 
     .footer a:hover { text-decoration: underline; }
 
+    .cookie-manage {
+      background: none;
+      border: none;
+      padding: 0;
+      font: inherit;
+      color: var(--link);
+      cursor: pointer;
+    }
+
+    .cookie-manage:hover, .cookie-manage:focus { text-decoration: underline; }
+    .cookie-manage:focus-visible { outline: 2px solid var(--accent-light); outline-offset: 2px; border-radius: 4px; }
+
     @media (max-width: 520px) {
       main { padding-top: 4.5rem; }
       .card { padding: 1.25rem; }
     }
   </style>
+  <script src="cookie-consent.js" defer></script>
 </head>
 <body>
   <main role="main">
@@ -185,7 +198,7 @@
 
     <a class="button" href="/">Back to homepage</a>
 
-    <p class="footer">Prefer not to hear from us? You can unsubscribe any time — each email includes a simple link.</p>
+    <p class="footer">Prefer not to hear from us? You can unsubscribe any time — each email includes a simple link. · <button type="button" class="cookie-manage" data-cookie-consent="manage">Cookie settings</button></p>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable cookie consent controller that blocks Google Analytics until analytics cookies are accepted
- surface "Cookie settings" controls across site pages and adjust copy for no-JavaScript scenarios
- refresh the privacy policy with GA4-specific wording, consent details, retention and processor updates

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cca35a9b64832194d859e02684daa9